### PR TITLE
Dictionary вместо массива для CarStatusResponse и cars

### DIFF
--- a/CityDrive/CityDrive/NetworkLayer/Model/CarStatusResponse.swift
+++ b/CityDrive/CityDrive/NetworkLayer/Model/CarStatusResponse.swift
@@ -4,11 +4,11 @@ struct CarStatusResponse: Codable {
     let insuranceKasko, insuranceLife: Int?
     let selfieUpload, showDestinationPoint, selectedAllCars, mailruComboTariff: Bool?
     let directPassDefault, directPassAllowed: Bool?
-    let preorderCars: [CarResponse]?
+    let preorderCars: [UUID: CarResponse]?
     let areaGroupDefaut: String?
     let discounts: DiscountsResponse?
 
-    let cars: [CarResponse]?
+    let cars: [UUID: CarResponse]?
 
     enum CodingKeys: String, CodingKey {
         case insuranceKasko = "insurance_kasko"
@@ -23,6 +23,47 @@ struct CarStatusResponse: Codable {
         case preorderCars = "preorder_cars"
         case areaGroupDefaut = "area_group_defaut"
         case discounts
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        insuranceKasko = try container.decodeIfPresent(Int.self, forKey: .insuranceKasko)
+        insuranceLife = try container.decodeIfPresent(Int.self, forKey: .insuranceLife)
+        selfieUpload = try container.decodeIfPresent(Bool.self, forKey: .selfieUpload)
+        showDestinationPoint = try container.decodeIfPresent(Bool.self, forKey: .showDestinationPoint)
+        selectedAllCars = try container.decodeIfPresent(Bool.self, forKey: .selectedAllCars)
+        mailruComboTariff = try container.decodeIfPresent(Bool.self, forKey: .mailruComboTariff)
+        directPassDefault = try container.decodeIfPresent(Bool.self, forKey: .directPassDefault)
+        directPassAllowed = try container.decodeIfPresent(Bool.self, forKey: .directPassAllowed)
+        areaGroupDefaut = try container.decodeIfPresent(String.self, forKey: .areaGroupDefaut)
+        discounts = try container.decodeIfPresent(DiscountsResponse.self, forKey: .discounts)
+
+        var carsDict = [UUID: CarResponse]()
+        var carsContainer = try container.nestedUnkeyedContainer(forKey: .cars)
+
+        var preorderCarsDict = [UUID: CarResponse]()
+        var preorderCarsContainer = try container.nestedUnkeyedContainer(forKey: .cars)
+
+        while !preorderCarsContainer.isAtEnd {
+            let carResponse = try preorderCarsContainer.decode(CarResponse.self)
+
+            if let carID = carResponse.carID, let uuid = UUID(uuidString: carID) {
+                preorderCarsDict[uuid] = carResponse
+            }
+        }
+
+        preorderCars = preorderCarsDict
+
+        while !carsContainer.isAtEnd {
+            let carResponse = try carsContainer.decode(CarResponse.self)
+
+            if let carID = carResponse.carID, let uuid = UUID(uuidString: carID) {
+                carsDict[uuid] = carResponse
+            }
+        }
+
+        cars = carsDict
     }
 }
 

--- a/CityDrive/CityDrive/View/Map/ImperativeMapView.swift
+++ b/CityDrive/CityDrive/View/Map/ImperativeMapView.swift
@@ -47,18 +47,13 @@ class MapViewController: UIViewController {
         mapView.removeAnnotations(mapView.annotations)
         mapVM.openCarDetail = false
 
-        var carAnnotations = [ImperativeMapPin]()
-
-        for car in mapVM.cars {
-            let pin = ImperativeMapPin(
-                id: car.id,
+        for (id, car) in mapVM.cars {
+            mapView.addAnnotation(ImperativeMapPin(
+                id: id,
                 coordinate: car.location.coordinate,
                 transferable: car.transferable
-            )
-            carAnnotations.append(pin)
+            ))
         }
-
-        mapView.addAnnotations(carAnnotations)
     }
 
     func goToUser() {

--- a/CityDrive/CityDrive/ViewModel/MapViewModel.swift
+++ b/CityDrive/CityDrive/ViewModel/MapViewModel.swift
@@ -59,17 +59,11 @@ class MapViewModel: ObservableObject {
                 print(error) // TODO: logging
                 return
             }
+            guard let carsDict = response?.cars else { return }
 
             var carsByArea = [UUID: Car]()
-
-            if let carsDict = response?.cars {
-                for (id, carResponse) in carsDict {
-                    if carResponse.areaGroupID != currentCity {
-                        continue
-                    }
-
-                    carsByArea[id] = carResponse.mapToCar()
-                }
+            for (id, carResponse) in carsDict where carResponse.areaGroupID != currentCity {
+                carsByArea[id] = carResponse.mapToCar()
             }
 
             DispatchQueue.main.async {

--- a/CityDrive/CityDrive/ViewModel/MapViewModel.swift
+++ b/CityDrive/CityDrive/ViewModel/MapViewModel.swift
@@ -5,7 +5,7 @@ import SwiftUI
 class MapViewModel: ObservableObject {
     private let networkManager: NetworkManager
 
-    @Published var cars: [Car] = []
+    @Published var cars: [UUID: Car] = [:]
     @Published var greenArea: GreenArea? = Settings.greenArea
     @Published var bonusBalance = ""
 
@@ -60,17 +60,20 @@ class MapViewModel: ObservableObject {
                 return
             }
 
-            guard let carsResponse: [CarResponse] = response?.cars else { return }
+            var carsByArea = [UUID: Car]()
 
-            var cars = [Car]()
+            if let carsDict = response?.cars {
+                for (id, carResponse) in carsDict {
+                    if carResponse.areaGroupID != currentCity {
+                        continue
+                    }
 
-            for carResponse in carsResponse where carResponse.areaGroupID == currentCity {
-                let car = carResponse.mapToCar()
-                cars.append(car)
+                    carsByArea[id] = carResponse.mapToCar()
+                }
             }
 
             DispatchQueue.main.async {
-                self.cars = cars
+                self.cars = carsByArea
                 self.carsIsLoaded = true
             }
         }
@@ -92,6 +95,6 @@ class MapViewModel: ObservableObject {
     func bookingCar() { }
 
     func setCurrentCar(id: UUID) {
-        self.currentCar = cars.first(where: { $0.id == id })
+        self.currentCar = cars[id]
     }
 }


### PR DESCRIPTION
Продолжаю поддерживать open source, на этот раз работа ещё более серьёзная. Жду ваших комментариев, Иван!

Приходит обычно 2-3 тысячи машин, в массив класть кажется не очень хорошей идеей, потому что

1. Нужно аллоцировать _непрерывное_ адресное пространство для такого большого ответа в случае использования массива
2.  В дальнейшем на карте тоже нужен dictionary, чтобы при каждом нажатии на пин не итерировалось по всему cars
3. Нам всё равно не важен порядок cars

> Первая проблема не так уж и страшна с современным железом, но why not?

Не очень хорошо, что таким образом структура API-ответа в коде немного отходит от JSON-схемы, но в целом окей, там всё остаётся читабельным.

Использована очень классная штука `container.nestedUnkeyedContainer`, которая, как я понимаю, позволяет постепенно читать JSON-массив, не записывая его перед этим куда-то целиком.

Ничего как будто не сломалось даже :)

<img width="504" alt="image" src="https://github.com/ubahwin/citydrive-unofficial/assets/46221547/d74868d9-6611-4a81-b5f0-d5b8d967b711">
